### PR TITLE
Fix broken pipe in local executor by managing copy fibers manually

### DIFF
--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -6,6 +6,7 @@ require "log"
 require "dotenv"
 require "colorize"
 require "digest/md5"
+require "wait_group"
 
 require "../src/craph"
 require "../src/docr"

--- a/spec/werk/local_executor_spec.cr
+++ b/spec/werk/local_executor_spec.cr
@@ -1,0 +1,56 @@
+require "../spec_helper"
+
+describe Werk::Executors::Local do
+  it "Crystal's internal process fiber corrupts exit code on broken pipe" do
+    Signal::PIPE.ignore
+
+    reader, writer = IO.pipe
+    reader.close
+
+    # Old approach: let Crystal's internal fiber handle the copy.
+    # The fiber hits EPIPE, closes the internal pipe early, and the
+    # child process gets killed by SIGPIPE → wrong exit code.
+    process = Process.new("echo", args: ["hello"],
+      output: writer,
+      error: Process::Redirect::Close,
+    )
+
+    status = process.wait
+    writer.close rescue nil
+
+    # echo should return 0, but Crystal's broken fiber kills it
+    status.exit_code.should_not eq(0)
+  end
+
+  it "should handle broken output pipe gracefully with manual copy" do
+    Signal::PIPE.ignore
+
+    reader, writer = IO.pipe
+    reader.close
+
+    # New approach: use Redirect::Pipe and copy ourselves with rescue.
+    # The child process runs to completion unaffected.
+    process = Process.new("echo", args: ["hello"],
+      output: Process::Redirect::Pipe,
+      error: Process::Redirect::Pipe,
+    )
+
+    done = Channel(Nil).new(2)
+
+    spawn do
+      IO.copy(process.output, writer) rescue nil
+      done.send(nil)
+    end
+
+    spawn do
+      IO.copy(process.error, writer) rescue nil
+      done.send(nil)
+    end
+
+    status = process.wait
+    2.times { done.receive }
+    writer.close rescue nil
+
+    status.exit_code.should eq(0)
+  end
+end

--- a/src/werk.cr
+++ b/src/werk.cr
@@ -7,6 +7,7 @@ require "option_parser"
 require "tallboy"
 require "colorize"
 require "digest/md5"
+require "wait_group"
 
 require "../src/craph"
 require "../src/docr"

--- a/src/werk/executors/local.cr
+++ b/src/werk/executors/local.cr
@@ -10,19 +10,34 @@ module Werk::Executors
       output : IO,
     ) : Int32
       Log.debug { "Starting process with #{job_config.interpreter} -c ..." }
+
+      # Use Redirect::Pipe so we control the output copy fibers ourselves.
+      # Crystal's internal copy fibers lack error handling, which causes
+      # "Unhandled exception in spawn: Broken pipe" at process exit.
       process = Process.new(job_config.interpreter,
         args: ["-c", job_config.script_content],
         shell: false,
         env: ctx.variables,
-        output: output,
-        error: output,
+        output: Process::Redirect::Pipe,
+        error: Process::Redirect::Pipe,
         chdir: ctx.directory,
       )
 
       @process = process
 
       begin
+        wg = WaitGroup.new
+        {process.output, process.error}.each do |src|
+          wg.spawn do
+            IO.copy(src, output)
+          rescue IO::Error
+            nil
+          end
+        end
+
         status = process.wait
+        wg.wait
+
         status.exit_code
       ensure
         @process = nil


### PR DESCRIPTION
Crystal's internal process copy fibers lack proper error handling, causing "Unhandled exception in spawn: Broken pipe" at process exit. Switch to Process::Redirect::Pipe and copy stdout/stderr manually with IO::Error rescue. Use WaitGroup for fiber synchronization.