### PR TITLE
Publish JUnit test reports in CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -69,7 +69,14 @@ jobs:
         run: shards install --ignore-crystal-version
 
       - name: Run tests
-        run: crystal spec
+        run: crystal spec --junit_output test-reports
+
+      - name: Publish test report
+        uses: mikepenz/action-junit-report@v6
+        if: success() || failure()
+        with:
+          report_paths: test-reports/**/*.xml
+          check_name: Tests (${{ matrix.os }})
 
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Add --junit_output to crystal spec and publish results via mikepenz/action-junit-report, one check per OS matrix entry.