### PR TITLE
Add ARM64 Linux support to CI/CD pipelines

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -18,6 +18,8 @@ jobs:
             asset: werk-darwin-arm64
           - os: ubuntu-latest
             asset: werk-linux-amd64
+          - os: ubuntu-24.04-arm
+            asset: werk-linux-arm64
 
     steps:
       - name: Install Crystal

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -9,29 +9,14 @@ env:
   APP_VERSION: ${{ github.event.release.tag_name }}
 
 jobs:
-  build:
-    runs-on: "${{ matrix.os }}"
-    strategy:
-      matrix:
-        include:
-          - os: macos-latest
-            asset: werk-darwin-arm64
-          - os: ubuntu-latest
-            asset: werk-linux-amd64
-          - os: ubuntu-24.04-arm
-            asset: werk-linux-arm64
+  build-macos:
+    runs-on: macos-latest
 
     steps:
       - name: Install Crystal
         uses: oprypin/install-crystal@v1
         with:
           crystal: 1.19.1
-
-      - name: Additional Linux dependencies
-        if: contains(matrix.os, 'ubuntu')
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libyaml-dev
 
       - name: Checkout code
         uses: actions/checkout@v4
@@ -43,15 +28,56 @@ jobs:
         run: shards install --production --ignore-crystal-version
 
       - name: Build
-        if: contains(matrix.os, 'macos')
         run: shards build --release --no-debug
 
+      - name: Upload application
+        uses: actions/upload-release-asset@v1
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ./bin/werk
+          asset_name: werk-darwin-arm64
+          asset_content_type: application/octet-stream
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Homebrew formula update
+        uses: mislav/bump-homebrew-formula-action@v1.12
+        env:
+          COMMITTER_TOKEN: ${{ secrets.COMMITTER_TOKEN }}
+        with:
+          formula-name: werk
+          homebrew-tap: marghidanu/homebrew-werk
+          base-branch: master
+
+  build-linux:
+    runs-on: "${{ matrix.os }}"
+    container:
+      image: 84codes/crystal:1.19.1-alpine
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-24.04
+            asset: werk-linux-amd64
+          - os: ubuntu-24.04-arm
+            asset: werk-linux-arm64
+
+    steps:
+      - name: Install build dependencies
+        run: apk add --no-cache yaml-static zlib-static
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Update shard version
+        run: sed -i "s/^version: .*/version: ${APP_VERSION}/" shard.yml
+
+      - name: Install dependencies
+        run: shards install --production --ignore-crystal-version
+
       - name: Build static
-        if: contains(matrix.os, 'ubuntu')
         run: shards build --release --no-debug --static
 
       - name: Upload application
-        id: upload
         uses: actions/upload-release-asset@v1
         with:
           upload_url: ${{ github.event.release.upload_url }}
@@ -61,18 +87,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Homebrew formula update
-        uses: mislav/bump-homebrew-formula-action@v1.12
-        if: contains(matrix.os, 'macos')
-        env:
-          COMMITTER_TOKEN: ${{ secrets.COMMITTER_TOKEN }}
-        with:
-          formula-name: werk
-          homebrew-tap: marghidanu/homebrew-werk
-          base-branch: master
-
-  docker:
-    runs-on: ubuntu-latest
+  build-docker:
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout code

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -41,6 +41,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Homebrew formula update
+        if: ${{ !github.event.release.prerelease }}
         uses: mislav/bump-homebrew-formula-action@v1.12
         env:
           COMMITTER_TOKEN: ${{ secrets.COMMITTER_TOKEN }}
@@ -63,13 +64,13 @@ jobs:
 
     steps:
       - name: Install build dependencies
-        run: apk add --no-cache yaml-static zlib-static
+        run: apk add --no-cache yaml-static zlib-static yq
 
       - name: Checkout code
         uses: actions/checkout@v4
 
       - name: Update shard version
-        run: sed -i "s/^version: .*/version: ${APP_VERSION}/" shard.yml
+        run: yq eval -i ".version = \"${APP_VERSION}\"" shard.yml
 
       - name: Install dependencies
         run: shards install --production --ignore-crystal-version

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,17 +15,7 @@ env:
   APP_VERSION: 0.0.${{ github.run_number }}
 
 jobs:
-  hadolint:
-    runs-on: ubuntu-24.04
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Hadolint
-        uses: hadolint/hadolint-action@v3.1.0
-
-  ameba:
+  lint:
     runs-on: ubuntu-24.04
 
     steps:
@@ -43,7 +33,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   test:
-    needs: ameba
+    needs: lint
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -88,12 +78,15 @@ jobs:
           check_name: Tests (${{ matrix.os }})
 
   build:
-    needs: hadolint
+    needs: test
     runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Hadolint
+        uses: hadolint/hadolint-action@v3.1.0
 
       - name: Simulate release version
         run: yq eval -i ".version = \"${APP_VERSION}\"" shard.yml

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -16,7 +16,7 @@ env:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout
@@ -39,7 +39,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-latest, ubuntu-latest, ubuntu-24.04-arm]
+        os: [macos-15, ubuntu-24.04, ubuntu-24.04-arm]
 
     steps:
       - name: Install Crystal
@@ -80,7 +80,7 @@ jobs:
           check_name: Tests (${{ matrix.os }})
 
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout code

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,7 +15,7 @@ env:
   APP_VERSION: 0.0.${{ github.run_number }}
 
 jobs:
-  lint:
+  hadolint:
     runs-on: ubuntu-24.04
 
     steps:
@@ -24,6 +24,13 @@ jobs:
 
       - name: Hadolint
         uses: hadolint/hadolint-action@v3.1.0
+
+  ameba:
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
 
       - name: Install Crystal
         uses: oprypin/install-crystal@v1
@@ -36,6 +43,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   test:
+    needs: ameba
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -80,6 +88,7 @@ jobs:
           check_name: Tests (${{ matrix.os }})
 
   build:
+    needs: hadolint
     runs-on: ubuntu-24.04
 
     steps:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -39,7 +39,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-15, ubuntu-24.04, ubuntu-24.04-arm]
+        os: [macos-latest, ubuntu-24.04, ubuntu-24.04-arm]
 
     steps:
       - name: Install Crystal

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -39,7 +39,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-latest, ubuntu-latest]
+        os: [macos-latest, ubuntu-latest, ubuntu-24.04-arm]
 
     steps:
       - name: Install Crystal
@@ -51,13 +51,14 @@ jobs:
         if: contains(matrix.os, 'ubuntu')
         run: |
           sudo apt-get update
-          sudo apt-get install -y libyaml-dev
+          sudo apt-get install -y libyaml-dev shellcheck
           GITLEAKS_VERSION=$(curl -s https://api.github.com/repos/gitleaks/gitleaks/releases/latest | grep -Po '"tag_name": "v\K[^"]+')
-          wget -qO- "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" | sudo tar xz -C /usr/local/bin gitleaks
+          ARCH=$(dpkg --print-architecture | sed 's/amd64/x64/')
+          wget -qO- "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_${ARCH}.tar.gz" | sudo tar xz -C /usr/local/bin gitleaks
 
       - name: Additional macOS dependencies
         if: contains(matrix.os, 'macos')
-        run: brew install gitleaks
+        run: brew install gitleaks shellcheck
 
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
- Add ubuntu-24.04-arm to CI test matrix
- Add ubuntu-24.04-arm to CD build matrix for werk-linux-arm64 static binary
- Make gitleaks download architecture-aware (dpkg --print-architecture)
- Install shellcheck on all CI runners (Linux apt + macOS brew)