### PR TITLE
Standardize error definitions and fix namespace references

### DIFF
--- a/spec/docr/containers_spec.cr
+++ b/spec/docr/containers_spec.cr
@@ -10,7 +10,7 @@ describe Docr::Containers do
 
     container = client.containers.create(
       "docr-test-logs",
-      Docr::ContainerConfig.new(
+      Docr::Types::ContainerConfig.new(
         image: "alpine:latest",
         cmd: ["sh", "-c", "echo hello from docker && echo error message >&2"],
       )
@@ -41,7 +41,7 @@ describe Docr::Containers do
 
     container = client.containers.create(
       "docr-test-exit",
-      Docr::ContainerConfig.new(
+      Docr::Types::ContainerConfig.new(
         image: "alpine:latest",
         cmd: ["sh", "-c", "exit 42"],
       )
@@ -58,9 +58,9 @@ describe Docr::Containers do
   end
 end
 
-describe Docr::ContainerConfig do
+describe Docr::Types::ContainerConfig do
   it "should serialize to JSON with PascalCase keys" do
-    config = Docr::ContainerConfig.new(
+    config = Docr::Types::ContainerConfig.new(
       image: "alpine:latest",
       cmd: ["/bin/sh"],
       working_dir: "/opt",
@@ -78,7 +78,7 @@ describe Docr::ContainerConfig do
   end
 
   it "should omit nil fields" do
-    config = Docr::ContainerConfig.new(image: "alpine")
+    config = Docr::Types::ContainerConfig.new(image: "alpine")
 
     json = JSON.parse(config.to_json)
 
@@ -88,9 +88,9 @@ describe Docr::ContainerConfig do
   end
 end
 
-describe Docr::HostConfig do
+describe Docr::Types::HostConfig do
   it "should serialize binds and network mode" do
-    host_config = Docr::HostConfig.new(
+    host_config = Docr::Types::HostConfig.new(
       network_mode: "host",
       binds: ["/src:/dst"],
     )
@@ -102,32 +102,32 @@ describe Docr::HostConfig do
   end
 end
 
-describe Docr::CreateContainerResponse do
+describe Docr::Types::CreateContainerResponse do
   it "should deserialize from JSON" do
-    response = Docr::CreateContainerResponse.from_json(%({"Id": "abc123", "Warnings": ["warn1"]}))
+    response = Docr::Types::CreateContainerResponse.from_json(%({"Id": "abc123", "Warnings": ["warn1"]}))
 
     response.id.should eq "abc123"
     response.warnings.should eq ["warn1"]
   end
 end
 
-describe Docr::WaitResponse do
+describe Docr::Types::WaitResponse do
   it "should deserialize status code" do
-    response = Docr::WaitResponse.from_json(%({"StatusCode": 0}))
+    response = Docr::Types::WaitResponse.from_json(%({"StatusCode": 0}))
 
     response.status_code.should eq 0
   end
 
   it "should deserialize non-zero status code" do
-    response = Docr::WaitResponse.from_json(%({"StatusCode": 137}))
+    response = Docr::Types::WaitResponse.from_json(%({"StatusCode": 137}))
 
     response.status_code.should eq 137
   end
 end
 
-describe Docr::ContainerSummary do
+describe Docr::Types::ContainerSummary do
   it "should deserialize from JSON" do
-    response = Docr::ContainerSummary.from_json(%({"Id": "abc123", "Names": ["/my-container"], "State": "running"}))
+    response = Docr::Types::ContainerSummary.from_json(%({"Id": "abc123", "Names": ["/my-container"], "State": "running"}))
 
     response.id.should eq "abc123"
     response.names.should eq ["/my-container"]

--- a/spec/docr/docr_spec.cr
+++ b/spec/docr/docr_spec.cr
@@ -39,16 +39,16 @@ describe Docr::Utils do
   end
 end
 
-describe Docr::DockerError do
+describe Docr::Error do
   it "should include status code and message" do
-    error = Docr::DockerError.new("no such container", 404)
+    error = Docr::Error.new("no such container", 404)
 
     error.status_code.should eq 404
     error.message.should eq "no such container"
   end
 
   it "should default status code to nil" do
-    error = Docr::DockerError.new("something went wrong")
+    error = Docr::Error.new("something went wrong")
 
     error.status_code.should be_nil
     error.message.should eq "something went wrong"

--- a/src/craph.cr
+++ b/src/craph.cr
@@ -1,2 +1,3 @@
+require "./craph/errors"
 require "./craph/graph"
 require "./craph/dag"

--- a/src/craph/dag.cr
+++ b/src/craph/dag.cr
@@ -1,6 +1,4 @@
 module Craph
-  class CycleError < Exception; end
-
   # Directed Acyclic Graph, extends Graph with cycle detection and topological sorting.
   class DAG(T) < Graph(T)
     # Check if the graph has no cycles using DFS

--- a/src/craph/errors.cr
+++ b/src/craph/errors.cr
@@ -1,0 +1,5 @@
+module Craph
+  class Error < Exception; end
+
+  class CycleError < Error; end
+end

--- a/src/docr/client.cr
+++ b/src/docr/client.cr
@@ -39,7 +39,7 @@ module Docr
       end
 
       path = SOCKET_PATHS.find { |sock| File.exists?(sock) }
-      raise DockerError.new("Docker socket not found. Set DOCKER_HOST or ensure Docker is running.") unless path
+      raise Error.new("Docker socket not found. Set DOCKER_HOST or ensure Docker is running.") unless path
 
       host = URI.new(scheme: "unix", host: "", path: path.to_s).to_s
       Log.debug { "Detected Docker socket: #{host}" }
@@ -49,7 +49,7 @@ module Docr
     def self.available? : Bool
       detect_host
       true
-    rescue DockerError
+    rescue Error
       false
     end
 
@@ -73,19 +73,11 @@ module Docr
       resource = url.is_a?(URI) ? url.to_s : url
       @client.exec(method, resource, headers, body) do |response|
         unless response.success?
-          raise DockerError.new(response.body_io.gets_to_end, response.status_code)
+          raise Error.new(response.body_io.gets_to_end, response.status_code)
         end
 
         yield response
       end
-    end
-  end
-
-  class DockerError < Exception
-    getter status_code : Int32?
-
-    def initialize(message : String, @status_code : Int32? = nil)
-      super(message)
     end
   end
 end

--- a/src/docr/containers.cr
+++ b/src/docr/containers.cr
@@ -7,7 +7,7 @@ module Docr
     end
 
     # Create a new container with the given name and configuration.
-    def create(name : String, config : ContainerConfig) : CreateContainerResponse
+    def create(name : String, config : Types::ContainerConfig) : Types::CreateContainerResponse
       url = URI.new(
         path: "/containers/create",
         query: URI::Params{
@@ -20,7 +20,7 @@ module Docr
       }
 
       @client.call("POST", url, headers, config.to_json) do |response|
-        return CreateContainerResponse.from_json(response.body_io.gets_to_end)
+        return Types::CreateContainerResponse.from_json(response.body_io.gets_to_end)
       end
     end
 
@@ -51,11 +51,11 @@ module Docr
     end
 
     # Block until a container stops, then return the exit code.
-    def wait(id : String) : WaitResponse
+    def wait(id : String) : Types::WaitResponse
       url = URI.new(path: "/containers/#{id}/wait")
 
       @client.call("POST", url) do |response|
-        return WaitResponse.from_json(response.body_io.gets_to_end)
+        return Types::WaitResponse.from_json(response.body_io.gets_to_end)
       end
     end
 
@@ -74,7 +74,7 @@ module Docr
     end
 
     # List containers, optionally filtered.
-    def list(filters : Hash(String, Array(String))? = nil) : Array(ContainerSummary)
+    def list(filters : Hash(String, Array(String))? = nil) : Array(Types::ContainerSummary)
       url = URI.new(
         path: "/containers/json",
         query: (filters ? URI::Params{
@@ -83,7 +83,7 @@ module Docr
       )
 
       @client.call("GET", url) do |response|
-        return Array(ContainerSummary).from_json(response.body_io.gets_to_end)
+        return Array(Types::ContainerSummary).from_json(response.body_io.gets_to_end)
       end
     end
 

--- a/src/docr/errors.cr
+++ b/src/docr/errors.cr
@@ -1,0 +1,9 @@
+module Docr
+  class Error < Exception
+    getter status_code : Int32?
+
+    def initialize(message : String, @status_code : Int32? = nil)
+      super(message)
+    end
+  end
+end

--- a/src/docr/images.cr
+++ b/src/docr/images.cr
@@ -12,7 +12,7 @@ module Docr
       end
 
       true
-    rescue DockerError
+    rescue Error
       false
     end
 

--- a/src/docr/types/containers.cr
+++ b/src/docr/types/containers.cr
@@ -1,86 +1,88 @@
 require "json"
 
 module Docr
-  class ContainerConfig
-    include JSON::Serializable
+  module Types
+    class ContainerConfig
+      include JSON::Serializable
 
-    @[JSON::Field(key: "Image")]
-    property image : String
+      @[JSON::Field(key: "Image")]
+      property image : String
 
-    @[JSON::Field(key: "Entrypoint")]
-    property entrypoint : Array(String)?
+      @[JSON::Field(key: "Entrypoint")]
+      property entrypoint : Array(String)?
 
-    @[JSON::Field(key: "Cmd")]
-    property cmd : Array(String)?
+      @[JSON::Field(key: "Cmd")]
+      property cmd : Array(String)?
 
-    @[JSON::Field(key: "WorkingDir")]
-    property working_dir : String?
+      @[JSON::Field(key: "WorkingDir")]
+      property working_dir : String?
 
-    @[JSON::Field(key: "Env")]
-    property env : Array(String)?
+      @[JSON::Field(key: "Env")]
+      property env : Array(String)?
 
-    @[JSON::Field(key: "Labels")]
-    property labels : Hash(String, String)?
+      @[JSON::Field(key: "Labels")]
+      property labels : Hash(String, String)?
 
-    @[JSON::Field(key: "HostConfig")]
-    property host_config : HostConfig?
+      @[JSON::Field(key: "HostConfig")]
+      property host_config : HostConfig?
 
-    def initialize(
-      @image,
-      @entrypoint = nil,
-      @cmd = nil,
-      @working_dir = nil,
-      env : Hash(String, String)? = nil,
-      @labels = nil,
-      @host_config = nil,
-    )
-      @env = env.try &.map { |k, v| "#{k}=#{v}" }
+      def initialize(
+        @image,
+        @entrypoint = nil,
+        @cmd = nil,
+        @working_dir = nil,
+        env : Hash(String, String)? = nil,
+        @labels = nil,
+        @host_config = nil,
+      )
+        @env = env.try &.map { |k, v| "#{k}=#{v}" }
+      end
     end
-  end
 
-  class HostConfig
-    include JSON::Serializable
+    class HostConfig
+      include JSON::Serializable
 
-    @[JSON::Field(key: "NetworkMode")]
-    property network_mode : String?
+      @[JSON::Field(key: "NetworkMode")]
+      property network_mode : String?
 
-    @[JSON::Field(key: "Binds")]
-    property binds : Array(String)?
+      @[JSON::Field(key: "Binds")]
+      property binds : Array(String)?
 
-    def initialize(@network_mode = nil, @binds = nil)
+      def initialize(@network_mode = nil, @binds = nil)
+      end
     end
-  end
 
-  struct CreateContainerResponse
-    include JSON::Serializable
+    struct CreateContainerResponse
+      include JSON::Serializable
 
-    @[JSON::Field(key: "Id")]
-    getter id : String
+      @[JSON::Field(key: "Id")]
+      getter id : String
 
-    @[JSON::Field(key: "Warnings")]
-    getter warnings : Array(String)?
-  end
+      @[JSON::Field(key: "Warnings")]
+      getter warnings : Array(String)?
+    end
 
-  struct WaitResponse
-    include JSON::Serializable
+    struct WaitResponse
+      include JSON::Serializable
 
-    @[JSON::Field(key: "StatusCode")]
-    getter status_code : Int32
-  end
+      @[JSON::Field(key: "StatusCode")]
+      getter status_code : Int32
+    end
 
-  struct ContainerSummary
-    include JSON::Serializable
+    struct ContainerSummary
+      include JSON::Serializable
 
-    @[JSON::Field(key: "Id")]
-    getter id : String
+      @[JSON::Field(key: "Id")]
+      getter id : String
 
-    @[JSON::Field(key: "Names")]
-    getter names : Array(String)?
+      @[JSON::Field(key: "Names")]
+      getter names : Array(String)?
 
-    @[JSON::Field(key: "Labels")]
-    getter labels : Hash(String, String)?
+      @[JSON::Field(key: "Labels")]
+      getter labels : Hash(String, String)?
 
-    @[JSON::Field(key: "State")]
-    getter state : String?
+      @[JSON::Field(key: "State")]
+      getter state : String?
+    end
   end
 end

--- a/src/tools/gitleaks.cr
+++ b/src/tools/gitleaks.cr
@@ -1,3 +1,1 @@
-require "./gitleaks/rules"
-require "./gitleaks/result"
-require "./gitleaks/scanner"
+require "./gitleaks/*"

--- a/src/tools/gitleaks/errors.cr
+++ b/src/tools/gitleaks/errors.cr
@@ -1,0 +1,3 @@
+module Gitleaks
+  class Error < Exception; end
+end

--- a/src/tools/gitleaks/scanner.cr
+++ b/src/tools/gitleaks/scanner.cr
@@ -1,6 +1,4 @@
 module Gitleaks
-  class Error < Exception; end
-
   class Scanner
     Log = ::Log.for(self)
 

--- a/src/vault/errors.cr
+++ b/src/vault/errors.cr
@@ -1,0 +1,3 @@
+module Vault
+  class Error < Exception; end
+end

--- a/src/vault/vault.cr
+++ b/src/vault/vault.cr
@@ -6,8 +6,6 @@ require "random/secure"
 module Vault
   Log = ::Log.for(self)
 
-  class Error < Exception; end
-
   # Stores a password XOR'd with a random pad so plaintext never
   # sits in memory. A memory dump would show random bytes.
   class ObfuscatedPassword

--- a/src/werk/commands/vault.cr
+++ b/src/werk/commands/vault.cr
@@ -10,11 +10,11 @@ module Werk::Commands
 
       case args.shift
       when "encrypt"
-        Werk::Commands::Encrypt.run(args)
+        Encrypt.run(args)
       when "decrypt"
-        Werk::Commands::Decrypt.run(args)
+        Decrypt.run(args)
       when "rekey"
-        Werk::Commands::Rekey.run(args)
+        Rekey.run(args)
       when "--help", "-h"
         print_help
       else

--- a/src/werk/commands/vault/decrypt.cr
+++ b/src/werk/commands/vault/decrypt.cr
@@ -1,4 +1,4 @@
-module Werk::Commands
+module Werk::Commands::Vault
   module Decrypt
     def self.run(args : Array(String))
       parser = OptionParser.new do |opt|

--- a/src/werk/commands/vault/encrypt.cr
+++ b/src/werk/commands/vault/encrypt.cr
@@ -1,4 +1,4 @@
-module Werk::Commands
+module Werk::Commands::Vault
   module Encrypt
     def self.run(args : Array(String))
       parser = OptionParser.new do |opt|

--- a/src/werk/commands/vault/rekey.cr
+++ b/src/werk/commands/vault/rekey.cr
@@ -1,4 +1,4 @@
-module Werk::Commands
+module Werk::Commands::Vault
   module Rekey
     def self.run(args : Array(String))
       parser = OptionParser.new do |opt|

--- a/src/werk/executors/docker.cr
+++ b/src/werk/executors/docker.cr
@@ -33,13 +33,13 @@ module Werk::Executors
       Log.debug { "Creating container '#{container_name}'" }
       container = client.containers.create(
         container_name,
-        Docr::ContainerConfig.new(
+        Docr::Types::ContainerConfig.new(
           image: image,
           entrypoint: entrypoint,
           cmd: ["-c", job.commands.join("\n")],
           working_dir: "/opt/workspace",
           env: interpolation.variables,
-          host_config: Docr::HostConfig.new(
+          host_config: Docr::Types::HostConfig.new(
             network_mode: network_mode,
             binds: [
               "#{Path[ctx.directory].expand}:/opt/workspace",
@@ -77,7 +77,7 @@ module Werk::Executors
         Log.debug { "Terminating container '#{container_id}'" }
         client.containers.kill(container_id, "SIGTERM")
       end
-    rescue ex : Docr::DockerError
+    rescue ex : Docr::Error
       Log.debug { "Failed to kill container: #{ex.message}" }
     end
 


### PR DESCRIPTION
Move error classes into dedicated errors.cr files following Crystal stdlib conventions (ModuleName::Error < Exception). Rename Docr::DockerError to Docr::Error, add Craph::Error as base for CycleError, extract Vault::Error and Gitleaks::Error from inline definitions.

Also fix Docr::Types namespace references after types module restructuring, and correct vault command dispatch paths.